### PR TITLE
Add project catalog

### DIFF
--- a/src/data/hydrate.ts
+++ b/src/data/hydrate.ts
@@ -1,0 +1,32 @@
+import { ProjectCatalog, ProjectDefinition, RawProjectCatalog, RawTileCatalog, TileCatalog } from '../game_logic'
+
+// Hydrate the cross references in these two maps so that lookups don't need to be made later
+export interface Catalogs {
+  tileCatalog: TileCatalog
+  projectCatalog: ProjectCatalog
+}
+export function hydrate (rawTiles: RawTileCatalog, rawProjects: RawProjectCatalog): Catalogs {
+  const tileCatalog: TileCatalog = {}
+  const projectCatalog: ProjectCatalog = {}
+
+  for (const projectId in rawProjects) {
+    projectCatalog[projectId] = Object.assign(
+      {},
+      rawProjects[projectId],
+      {
+        targetTileDefinition: rawTiles[rawProjects[projectId].targetTileDefinition]
+      }
+    ) as unknown as ProjectDefinition
+  }
+
+  for (const tileId in rawTiles) {
+    tileCatalog[tileId] = Object.assign(rawTiles[tileId], {
+      projects: rawTiles[tileId].projects.map((id) => projectCatalog[id])
+    })
+  }
+
+  return {
+    tileCatalog,
+    projectCatalog
+  }
+}

--- a/src/data/project-catalog.ts
+++ b/src/data/project-catalog.ts
@@ -1,0 +1,19 @@
+import { RawProjectCatalog } from '../game_logic'
+
+// This file implements a "database" of tiles, each with unique appearance, choices, etc
+export const catalog: RawProjectCatalog = {
+  'repair-firehouse': {
+    name: 'Repair',
+    description: 'Fix it up!',
+    targetTileDefinition: 'firehouse-1',
+    cost: 300,
+    effort: 9
+  },
+  demolish: {
+    name: 'Demolish',
+    description: 'Tear it down!',
+    targetTileDefinition: 'empty',
+    cost: 500,
+    effort: 20
+  }
+}

--- a/src/data/tile-catalog.ts
+++ b/src/data/tile-catalog.ts
@@ -1,7 +1,7 @@
-import { TileCatalog } from '../game_logic'
+import { RawTileCatalog } from '../game_logic/interfaces'
 
 // This file implements a "database" of tiles, each with unique appearance, choices, etc
-export const catalog: TileCatalog = {
+export const catalog: RawTileCatalog = {
   empty: {
     name: 'Empty Lot',
     description: '',
@@ -17,13 +17,8 @@ export const catalog: TileCatalog = {
     happiness: 0,
     revenue: 0,
     projects: [
-      {
-        name: 'Repair',
-        description: 'Fix it up!',
-        targetCatalogEntryId: 'firehouse-1',
-        cost: 300,
-        effort: 9
-      }
+      'repair-firehouse',
+      'demolish'
     ]
   },
   'firehouse-1': {
@@ -32,6 +27,8 @@ export const catalog: TileCatalog = {
     tags: ['repaired', 'improved', 'public-service'],
     revenue: -5,
     happiness: 10,
-    projects: []
+    projects: [
+      'demolish'
+    ]
   }
 }

--- a/src/game_logic/index.ts
+++ b/src/game_logic/index.ts
@@ -1,11 +1,11 @@
-import { GameMapDefinition, GameState, isTileUnderConstruction, Tile, TileCatalog, TileCatalogEntryId, TileUnderConstruction } from './interfaces'
+import { GameMapDefinition, GameState, isTileUnderConstruction, Tile, TileCatalog, TileCatalogEntryId, TileUnderConstruction, ProjectCatalog } from './interfaces'
 import { advanceTurnCounter, applyRevenue, applyWorkers, checkWinLoss, resetWorkers, resolveContracts } from './turn'
 export * from './interfaces'
 
 const STARTING_MONEY = 1000000
 const STARTING_WORKERS = 3
 
-export function createGameState (mapDefinition: GameMapDefinition, tileCatalog: TileCatalog): GameState {
+export function createGameState (mapDefinition: GameMapDefinition, tileCatalog: TileCatalog, projectCatalog: ProjectCatalog): GameState {
   const state = {
     game: {
       turnCounter: 0
@@ -31,25 +31,26 @@ export function createGameState (mapDefinition: GameMapDefinition, tileCatalog: 
       }
     },
     map: {
-      tiles: initializeTiles(mapDefinition, tileCatalog),
+      tiles: initializeTiles(mapDefinition, tileCatalog, projectCatalog),
       size: mapDefinition.size
     },
-    tileCatalog
+    tileCatalog,
+    projectCatalog
   }
 
   return state
 }
 
-function initializeTiles (mapDefinition: GameMapDefinition, tileCatalog: TileCatalog): Array<Tile> {
+function initializeTiles (mapDefinition: GameMapDefinition, tileCatalog: TileCatalog, projectCatalog: ProjectCatalog): Array<Tile> {
   return mapDefinition.tiles.map((catalogEntryId: TileCatalogEntryId): Tile => ({
-    catalogEntry: tileCatalog[catalogEntryId]
+    definition: tileCatalog[catalogEntryId]
   }))
 }
 
 export function playerInitiateProject (state: GameState, tileIndex: number, projectIndex: number) {
   const tile = state.map.tiles[tileIndex] as TileUnderConstruction
   tile.activeProject = {
-    project: tile.catalogEntry.projects[projectIndex],
+    project: tile.definition.projects[projectIndex],
     progress: 0,
     assignedWorkers: 0
   }

--- a/src/game_logic/interfaces.ts
+++ b/src/game_logic/interfaces.ts
@@ -1,13 +1,21 @@
 /**
  * Represents the project a player assigns workers to in order to improve a tile.
  */
-export interface TileImprovementProject {
+export interface ProjectCatalogEntry {
   readonly name: string
   readonly description: string
-  readonly targetCatalogEntryId: TileCatalogEntryId
+  readonly targetTileDefinition: string
   readonly cost: number
   readonly effort: number
 }
+
+export interface ProjectDefinition extends Omit<ProjectCatalogEntry, 'targetTileDefinition'> {
+  readonly targetTileDefinition: TileDefinition
+}
+
+export type ProjectCatalogId = string
+export type RawProjectCatalog = Record<ProjectCatalogId, ProjectCatalogEntry>
+export type ProjectCatalog = Record<ProjectCatalogId, ProjectDefinition>
 
 /**
  * A TileDBEntry stores the "starting point" and static information about tiles
@@ -20,18 +28,23 @@ export interface TileCatalogEntry {
   readonly description: string
   // An array of 0 to 3 projects for a tile
   // 0 projects indicates a "final" tile that can't be improved any more
-  readonly projects: Array<TileImprovementProject>
+  readonly projects: Array<ProjectCatalogId>
   // An array of "tags" that categorize this tile.
   readonly tags: Array<string>
   readonly revenue: number
   readonly happiness: number
 }
 
-export type TileCatalogEntryId = string;
-export type TileCatalog = Record<TileCatalogEntryId, TileCatalogEntry>;
+export interface TileDefinition extends Omit<TileCatalogEntry, 'projects'> {
+  readonly projects: Array<ProjectDefinition>
+}
+
+export type TileCatalogEntryId = string
+export type RawTileCatalog = Record<TileCatalogEntryId, TileCatalogEntry>
+export type TileCatalog = Record<TileCatalogEntryId, TileDefinition>
 
 export interface ActiveProject {
-  readonly project: TileImprovementProject
+  readonly project: ProjectDefinition
   // Invariant: progress < project.effort
   progress: number
   assignedWorkers: number
@@ -42,13 +55,12 @@ export interface ActiveProject {
  */
 export interface Tile {
   // Pointer into a database of tile decsriptions that are IMMUTABLE
-  catalogEntry: TileCatalogEntry
+  definition: TileDefinition
+
   activeProject?: ActiveProject
 }
 
 export interface TileUnderConstruction extends Tile {
-  // Pointer into a database of tile decsriptions that are IMMUTABLE
-  catalogEntryId: TileCatalogEntryId
   // Defined if this tile is currently under construction
   activeProject: ActiveProject
 }

--- a/src/game_logic/turn.ts
+++ b/src/game_logic/turn.ts
@@ -21,9 +21,13 @@ export function applyWorkersAtTile (state: GameState, tile: Tile) {
     // Check if project is done
     if (tile.activeProject.progress === tile.activeProject.project.effort) {
       // Change the catalog entry
-      tile.catalogEntry = state.tileCatalog[tile.activeProject.project.targetCatalogEntryId]
+      tile.definition = tile.activeProject.project.targetTileDefinition
       const t = tile as Tile
       delete t.activeProject
+
+      // Give player rewards for the tile
+      state.player.victory.happiness += tile.definition.happiness
+      state.player.resources.money.revenue += tile.definition.revenue
     }
   }
 }

--- a/src/play_game_logic.ts
+++ b/src/play_game_logic.ts
@@ -1,11 +1,15 @@
 import { advanceTurn, createGameState, playerAssignWorkers, playerInitiateProject, TileUnderConstruction } from './game_logic/index'
 import { map } from './data/map'
-import { catalog } from './data/tile-catalog'
+import { catalog as tileCatalog } from './data/tile-catalog'
+import { catalog as projectCatalog } from './data/project-catalog'
+import { hydrate } from './data/hydrate'
 
 export function playGameLogic () {
-// To begin the game, we need an initial state
-// However, that state will be initialized from a description of the game map and a tile catalog
-  const state = createGameState(map, catalog)
+  const catalogs = hydrate(tileCatalog, projectCatalog)
+
+  // To begin the game, we need an initial state
+  // However, that state will be initialized from a description of the game map and a tile catalog
+  const state = createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog)
 
   // We  will mimic a few player turns and inspect the state
 
@@ -18,7 +22,7 @@ export function playGameLogic () {
 
   // Inspect the tile to see what it is
   let tile = (state.map.tiles.at(selectedTileIndex) as TileUnderConstruction)
-  console.log(tile.catalogEntry)
+  console.log(tile.definition)
 
   // Commit that action: "Start repairing the fire station"
   playerInitiateProject(state, selectedTileIndex, selectedProjectIndex)
@@ -67,5 +71,5 @@ export function playGameLogic () {
   // Inspect the state of the game and see how work is progressing
   // MAJOR TODO: make it easier to inspect this state
   tile = (state.map.tiles.at(selectedTileIndex) as TileUnderConstruction)
-  console.log(tile.catalogEntry)
+  console.log(tile.definition)
 }


### PR DESCRIPTION
* Projects now form their own catalog
* Project Catalog references target tile by id
* Tile catalog references projects by id
* At game start, these two catalogs are "hydrated" by replacing id's with actual object references