### PR TITLE
Prevent mouse clicks from piercing objects

### DIFF
--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -41,7 +41,14 @@ export function GameView (props: {gameState: GameState, uiState: UiState, dispat
 
 export function GameViewPort (props) {
   return (
-    <Canvas>
+    <Canvas
+      raycaster={{
+        filter: (items, state) => {
+          if (items.length > 0) { return [items[0]] }
+          return []
+        }
+      }}
+    >
       <GameView {...props} />
     </Canvas>
   )


### PR DESCRIPTION
Requires #14. Will switch base branch once it merges.

This prevents multiple click events for a single MapLocation, or selecting the *last* one when you line up a shot through several.