### PR TITLE
Add a close button to the tile summary pane and reorganize reducer code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11300,9 +11300,9 @@
             }
         },
         "@mui/icons-material": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.2.1.tgz",
-            "integrity": "sha512-AFOn0bbaGd1dw8oYE40dv3I+QnfS5xP5HSUiUGsvb1ntP0cM1kW4VqQp7BtL7DbOpEsw1ZTbw67tDqSCH7utNg==",
+            "version": "5.2.4",
+            "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.2.4.tgz",
+            "integrity": "sha512-ekeOpSYFVYtNX2P+5oENXlCVQkT/Bm4XJBUTsdVYpqdoVBFSzygJMvNiq9HfAItSK3aBW7gMpypnDnN7CfjjOQ==",
             "dev": true,
             "requires": {
                 "@babel/runtime": "^7.16.3"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "@babel/preset-typescript": "^7.16.0",
         "@emotion/react": "^11.7.0",
         "@emotion/styled": "^11.6.0",
-        "@mui/icons-material": "^5.2.1",
+        "@mui/icons-material": "^5.2.4",
         "@mui/material": "^5.2.2",
         "@popperjs/core": "^2.11.0",
         "@react-three/drei": "^8.0.0",

--- a/src/components/GameDisplay.tsx
+++ b/src/components/GameDisplay.tsx
@@ -18,12 +18,12 @@ export function GameDisplay (props) {
   }
 
   const [gameState, dispatch] = useReducer(gameReducer, startingState)
-  const [uiState, dispatchUI] = useReducer(uiReducer, startingUiState)
+  const [uiState, dispatchUi] = useReducer(uiReducer, startingUiState)
 
   return (
     <div className='container'>
-      <GameViewPort gameState={gameState} uiState={uiState} dispatchUi={dispatchUI} />
-      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUI={dispatchUI} />
+      <GameViewPort gameState={gameState} uiState={uiState} dispatchUi={dispatchUi} />
+      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUi={dispatchUi} />
     </div>
   )
 }

--- a/src/components/GameDisplay.tsx
+++ b/src/components/GameDisplay.tsx
@@ -5,7 +5,7 @@ import { catalog as projectCatalog } from '../data/project-catalog'
 import { catalog as tileCatalog } from '../data/tile-catalog'
 import { createGameState } from '../game_logic'
 import { Hud } from './Hud'
-import { gameReducer, uiReducer, UiState } from './reducers'
+import { gameReducer, uiReducer, UIState } from './reducers'
 import { GameViewPort } from './view/GameViewPort'
 
 export function GameDisplay (props) {
@@ -14,16 +14,16 @@ export function GameDisplay (props) {
   // To begin the game, we need an initial state
   // However, that state will be initialized from a description of the game map and a tile catalog
   const startingState = createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog)
-  const startingUiState: UiState = {
+  const startingUIState: UIState = {
   }
 
   const [gameState, dispatch] = useReducer(gameReducer, startingState)
-  const [uiState, dispatchUi] = useReducer(uiReducer, startingUiState)
+  const [uiState, dispatchUI] = useReducer(uiReducer, startingUIState)
 
   return (
     <div className='container'>
-      <GameViewPort gameState={gameState} uiState={uiState} dispatchUi={dispatchUi} />
-      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUi={dispatchUi} />
+      <GameViewPort gameState={gameState} uiState={uiState} dispatchUI={dispatchUI} />
+      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUI={dispatchUI} />
     </div>
   )
 }

--- a/src/components/GameDisplay.tsx
+++ b/src/components/GameDisplay.tsx
@@ -5,7 +5,7 @@ import { catalog as projectCatalog } from '../data/project-catalog'
 import { catalog as tileCatalog } from '../data/tile-catalog'
 import { createGameState } from '../game_logic'
 import { Hud } from './Hud'
-import { gameReducer, uiReducer, UIState } from './reducers'
+import { reducer, State } from './reducers'
 import { GameViewPort } from './view/GameViewPort'
 
 export function GameDisplay (props) {
@@ -13,17 +13,17 @@ export function GameDisplay (props) {
 
   // To begin the game, we need an initial state
   // However, that state will be initialized from a description of the game map and a tile catalog
-  const startingState = createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog)
-  const startingUIState: UIState = {
+  const startingState: State = {
+    game: createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog),
+    ui: {}
   }
 
-  const [gameState, dispatch] = useReducer(gameReducer, startingState)
-  const [uiState, dispatchUI] = useReducer(uiReducer, startingUIState)
+  const [state, dispatch] = useReducer(reducer, startingState)
 
   return (
     <div className='container'>
-      <GameViewPort gameState={gameState} uiState={uiState} dispatchUI={dispatchUI} />
-      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUI={dispatchUI} />
+      <GameViewPort state={state} dispatch={dispatch} />
+      <Hud state={state} dispatch={dispatch} />
     </div>
   )
 }

--- a/src/components/GameDisplay.tsx
+++ b/src/components/GameDisplay.tsx
@@ -5,7 +5,7 @@ import { catalog as projectCatalog } from '../data/project-catalog'
 import { catalog as tileCatalog } from '../data/tile-catalog'
 import { createGameState } from '../game_logic'
 import { Hud } from './Hud'
-import { gameReducer, uiReducer, UIState } from './reducers'
+import { gameReducer, uiReducer, UiState } from './reducers'
 import { GameViewPort } from './view/GameViewPort'
 
 export function GameDisplay (props) {
@@ -14,7 +14,7 @@ export function GameDisplay (props) {
   // To begin the game, we need an initial state
   // However, that state will be initialized from a description of the game map and a tile catalog
   const startingState = createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog)
-  const startingUiState: UIState = {
+  const startingUiState: UiState = {
   }
 
   const [gameState, dispatch] = useReducer(gameReducer, startingState)

--- a/src/components/GameDisplay.tsx
+++ b/src/components/GameDisplay.tsx
@@ -3,54 +3,27 @@ import { hydrate } from '../data/hydrate'
 import { map } from '../data/map'
 import { catalog as projectCatalog } from '../data/project-catalog'
 import { catalog as tileCatalog } from '../data/tile-catalog'
-import { advanceTurn, createGameState, GameState } from '../game_logic'
+import { createGameState } from '../game_logic'
 import { Hud } from './Hud'
+import { gameReducer, uiReducer, UIState } from './reducers'
 import { GameViewPort } from './view/GameViewPort'
 
-export interface UiState {
-  selectedTile?: number
-}
-
-export interface GameAction {
-  type: string
-  projectIndex?: number
-}
-function reducer (state: GameState, action: GameAction): GameState {
-  console.log(action)
-  switch (action.type) {
-    case 'advanceTurn':
-      advanceTurn(state)
-  }
-  return Object.assign({}, state)
-}
-
-function uiReducer (state: UiState, action: {type: string, tileIndex: number}): UiState {
-  switch (action.type) {
-    case 'selectTile':
-      return Object.assign({}, state, { selectedTile: action.tileIndex })
-    default:
-      return Object.assign({}, state)
-  }
-}
-export type uiDispatcher = (action: {type: string, tileIndex: number}) => void
-export type GameDispatch = (action: GameAction) => void
-
-export function GameDisplay () {
+export function GameDisplay (props) {
   const catalogs = hydrate(tileCatalog, projectCatalog)
 
   // To begin the game, we need an initial state
   // However, that state will be initialized from a description of the game map and a tile catalog
   const startingState = createGameState(map, catalogs.tileCatalog, catalogs.projectCatalog)
-  const startingUiState: UiState = {
+  const startingUiState: UIState = {
   }
 
-  const [gameState, dispatch] = useReducer(reducer, startingState)
+  const [gameState, dispatch] = useReducer(gameReducer, startingState)
   const [uiState, dispatchUI] = useReducer(uiReducer, startingUiState)
 
   return (
     <div className='container'>
       <GameViewPort gameState={gameState} uiState={uiState} dispatchUi={dispatchUI} />
-      <Hud gameState={gameState} uiState={uiState} dispatch={dispatch} />
+      <Hud gameState={gameState} uiState={uiState} dispatchGame={dispatch} dispatchUI={dispatchUI} />
     </div>
   )
 }

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -2,16 +2,16 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Accordion, AccordionDetails, AccordionSummary, Fab, Typography } from '@mui/material'
 import { GameState, Tile } from '../game_logic'
 import { ContractPane } from './ContractPane'
-import { UiState, gameDispatcher, uiDispatcher } from './reducers'
+import { UIState, gameDispatcher, uiDispatcher } from './reducers'
 import { TileSummary } from './hud/TileSummary'
 import { PlayerSummaryPane } from './PlayerSummaryPane'
 import NextPlanIcon from '@mui/icons-material/NextPlan'
 
 export function Hud (props: {
   gameState: GameState,
-  uiState: UiState,
+  uiState: UIState,
   dispatchGame: gameDispatcher,
-  dispatchUi: uiDispatcher
+  dispatchUI: uiDispatcher
 }) {
   const nextTurn = () => {
     props.dispatchGame({ type: 'advanceTurn' })
@@ -45,7 +45,7 @@ export function Hud (props: {
         </Accordion>
       </div>
       <div className='bottom-hud'>
-        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUi={props.dispatchUi} />
+        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUI={props.dispatchUI} />
       </div>
       <div className='bottom-hud-right'>
         <Fab variant='extended' size='large' color='secondary' aria-label='add' onClick={nextTurn}>

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -11,7 +11,7 @@ export function Hud (props: {
   gameState: GameState,
   uiState: UiState,
   dispatchGame: gameDispatcher,
-  dispatchUI: uiDispatcher
+  dispatchUi: uiDispatcher
 }) {
   const nextTurn = () => {
     props.dispatchGame({ type: 'advanceTurn' })
@@ -45,7 +45,7 @@ export function Hud (props: {
         </Accordion>
       </div>
       <div className='bottom-hud'>
-        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUI={props.dispatchUI} />
+        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUi={props.dispatchUi} />
       </div>
       <div className='bottom-hud-right'>
         <Fab variant='extended' size='large' color='secondary' aria-label='add' onClick={nextTurn}>

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -2,14 +2,19 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Accordion, AccordionDetails, AccordionSummary, Fab, Typography } from '@mui/material'
 import { GameState, Tile } from '../game_logic'
 import { ContractPane } from './ContractPane'
-import { UiState, GameDispatch } from './GameDisplay'
+import { UIState, gameDispatcher, uiDispatcher } from './reducers'
 import { TileSummary } from './hud/TileSummary'
 import { PlayerSummaryPane } from './PlayerSummaryPane'
 import NextPlanIcon from '@mui/icons-material/NextPlan'
 
-export function Hud (props: {gameState: GameState, uiState: UiState, dispatch: GameDispatch}) {
+export function Hud (props: {
+  gameState: GameState,
+  uiState: UIState,
+  dispatchGame: gameDispatcher,
+  dispatchUI: uiDispatcher
+}) {
   const nextTurn = () => {
-    props.dispatch({ type: 'advanceTurn' })
+    props.dispatchGame({ type: 'advanceTurn' })
   }
 
   let selectedTile: Tile | undefined
@@ -40,7 +45,7 @@ export function Hud (props: {gameState: GameState, uiState: UiState, dispatch: G
         </Accordion>
       </div>
       <div className='bottom-hud'>
-        <TileSummary tile={selectedTile} dispatch={props.dispatch} />
+        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUI={props.dispatchUI} />
       </div>
       <div className='bottom-hud-right'>
         <Fab variant='extended' size='large' color='secondary' aria-label='add' onClick={nextTurn}>

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -1,25 +1,23 @@
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Accordion, AccordionDetails, AccordionSummary, Fab, Typography } from '@mui/material'
-import { GameState, Tile } from '../game_logic'
+import { Tile } from '../game_logic'
 import { ContractPane } from './ContractPane'
-import { UIState, gameDispatcher, uiDispatcher } from './reducers'
+import { State, dispatcher } from './reducers'
 import { TileSummary } from './hud/TileSummary'
 import { PlayerSummaryPane } from './PlayerSummaryPane'
 import NextPlanIcon from '@mui/icons-material/NextPlan'
 
 export function Hud (props: {
-  gameState: GameState,
-  uiState: UIState,
-  dispatchGame: gameDispatcher,
-  dispatchUI: uiDispatcher
+  state: State,
+  dispatch: dispatcher
 }) {
   const nextTurn = () => {
-    props.dispatchGame({ type: 'advanceTurn' })
+    props.dispatch({ type: 'advanceTurn' })
   }
 
   let selectedTile: Tile | undefined
-  if (props.uiState.selectedTile !== undefined) {
-    selectedTile = props.gameState.map.tiles[props.uiState.selectedTile]
+  if (props.state.ui.selectedTile !== undefined) {
+    selectedTile = props.state.game.map.tiles[props.state.ui.selectedTile]
   }
 
   return (
@@ -32,7 +30,7 @@ export function Hud (props: {
             <Typography variant='h6'>Summary</Typography>
           </AccordionSummary>
           <AccordionDetails>
-            <PlayerSummaryPane id='playerSummaryPane' playerState={props.gameState.player} />
+            <PlayerSummaryPane id='playerSummaryPane' playerState={props.state.game.player} />
           </AccordionDetails>
         </Accordion>
         <Accordion defaultExpanded className='hud-pane-expander'>
@@ -45,7 +43,7 @@ export function Hud (props: {
         </Accordion>
       </div>
       <div className='bottom-hud'>
-        <TileSummary tile={selectedTile} dispatchGame={props.dispatchGame} dispatchUI={props.dispatchUI} />
+        <TileSummary tile={selectedTile} dispatch={props.dispatch} />
       </div>
       <div className='bottom-hud-right'>
         <Fab variant='extended' size='large' color='secondary' aria-label='add' onClick={nextTurn}>

--- a/src/components/Hud.tsx
+++ b/src/components/Hud.tsx
@@ -2,14 +2,14 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import { Accordion, AccordionDetails, AccordionSummary, Fab, Typography } from '@mui/material'
 import { GameState, Tile } from '../game_logic'
 import { ContractPane } from './ContractPane'
-import { UIState, gameDispatcher, uiDispatcher } from './reducers'
+import { UiState, gameDispatcher, uiDispatcher } from './reducers'
 import { TileSummary } from './hud/TileSummary'
 import { PlayerSummaryPane } from './PlayerSummaryPane'
 import NextPlanIcon from '@mui/icons-material/NextPlan'
 
 export function Hud (props: {
   gameState: GameState,
-  uiState: UIState,
+  uiState: UiState,
   dispatchGame: gameDispatcher,
   dispatchUI: uiDispatcher
 }) {

--- a/src/components/hud/ProjectsDisplay.tsx
+++ b/src/components/hud/ProjectsDisplay.tsx
@@ -1,9 +1,9 @@
 import { Tile } from '../../game_logic'
-import { GameDispatch } from '../reducers'
+import { gameDispatcher } from '../reducers'
 import { ActiveProjectDisplay } from './ActiveProjectDisplay'
 import { SelectProjectDisplay } from './SelectProjectDisplay'
 
-export function ProjectsDisplay (props: {tile?: Tile, dispatchGame: GameDispatch }) {
+export function ProjectsDisplay (props: {tile?: Tile, dispatchGame: gameDispatcher }) {
   if (!props.tile) {
     return (<></>)
   }

--- a/src/components/hud/ProjectsDisplay.tsx
+++ b/src/components/hud/ProjectsDisplay.tsx
@@ -1,9 +1,9 @@
 import { Tile } from '../../game_logic'
-import { gameDispatcher } from '../reducers'
+import { dispatcher } from '../reducers'
 import { ActiveProjectDisplay } from './ActiveProjectDisplay'
 import { SelectProjectDisplay } from './SelectProjectDisplay'
 
-export function ProjectsDisplay (props: {tile?: Tile, dispatchGame: gameDispatcher }) {
+export function ProjectsDisplay (props: {tile?: Tile, dispatch: dispatcher }) {
   if (!props.tile) {
     return (<></>)
   }
@@ -12,6 +12,6 @@ export function ProjectsDisplay (props: {tile?: Tile, dispatchGame: gameDispatch
     // Show worker assignment display
     return (<ActiveProjectDisplay activeProject={props.tile.activeProject} />)
   } else {
-    return (<SelectProjectDisplay tile={props.tile} dispatch={props.dispatchGame} />)
+    return (<SelectProjectDisplay tile={props.tile} dispatch={props.dispatch} />)
   }
 }

--- a/src/components/hud/ProjectsDisplay.tsx
+++ b/src/components/hud/ProjectsDisplay.tsx
@@ -1,9 +1,9 @@
 import { Tile } from '../../game_logic'
-import { GameDispatch } from '../GameDisplay'
+import { GameDispatch } from '../reducers'
 import { ActiveProjectDisplay } from './ActiveProjectDisplay'
 import { SelectProjectDisplay } from './SelectProjectDisplay'
 
-export function ProjectsDisplay (props: {tile?: Tile, dispatch: GameDispatch }) {
+export function ProjectsDisplay (props: {tile?: Tile, dispatchGame: GameDispatch }) {
   if (!props.tile) {
     return (<></>)
   }
@@ -12,6 +12,6 @@ export function ProjectsDisplay (props: {tile?: Tile, dispatch: GameDispatch }) 
     // Show worker assignment display
     return (<ActiveProjectDisplay activeProject={props.tile.activeProject} />)
   } else {
-    return (<SelectProjectDisplay tile={props.tile} dispatch={props.dispatch} />)
+    return (<SelectProjectDisplay tile={props.tile} dispatch={props.dispatchGame} />)
   }
 }

--- a/src/components/hud/SelectProjectDisplay.tsx
+++ b/src/components/hud/SelectProjectDisplay.tsx
@@ -1,8 +1,8 @@
 import { Button, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
 import { Tile } from '../../game_logic'
-import { gameDispatcher } from '../reducers'
+import { dispatcher } from '../reducers'
 
-export function SelectProjectDisplay (props: {tile: Tile, dispatch: gameDispatcher}) {
+export function SelectProjectDisplay (props: {tile: Tile, dispatch: dispatcher}) {
   const projects = props.tile.definition.projects
   console.log('projects', projects, props.tile)
   const projectList = projects.map((project, index) => {

--- a/src/components/hud/SelectProjectDisplay.tsx
+++ b/src/components/hud/SelectProjectDisplay.tsx
@@ -1,8 +1,8 @@
 import { Button, Table, TableBody, TableCell, TableHead, TableRow, Typography } from '@mui/material'
 import { Tile } from '../../game_logic'
-import { GameDispatch } from '../GameDisplay'
+import { gameDispatcher } from '../reducers'
 
-export function SelectProjectDisplay (props: {tile: Tile, dispatch: GameDispatch}) {
+export function SelectProjectDisplay (props: {tile: Tile, dispatch: gameDispatcher}) {
   const projects = props.tile.definition.projects
   console.log('projects', projects, props.tile)
   const projectList = projects.map((project, index) => {

--- a/src/components/hud/TileSummary.tsx
+++ b/src/components/hud/TileSummary.tsx
@@ -7,14 +7,14 @@ import CloseIcon from '@mui/icons-material/Close'
 export function TileSummary (props: {
   tile?: Tile,
   dispatchGame: gameDispatcher,
-  dispatchUI: uiDispatcher
+  dispatchUi: uiDispatcher
 }) {
   if (!props.tile) {
     return (<div />)
   }
 
   const onCloseClick = () => {
-    props.dispatchUI({
+    props.dispatchUi({
       type: 'deselectTile'
     })
   }

--- a/src/components/hud/TileSummary.tsx
+++ b/src/components/hud/TileSummary.tsx
@@ -7,14 +7,14 @@ import CloseIcon from '@mui/icons-material/Close'
 export function TileSummary (props: {
   tile?: Tile,
   dispatchGame: gameDispatcher,
-  dispatchUi: uiDispatcher
+  dispatchUI: uiDispatcher
 }) {
   if (!props.tile) {
     return (<div />)
   }
 
   const onCloseClick = () => {
-    props.dispatchUi({
+    props.dispatchUI({
       type: 'deselectTile'
     })
   }

--- a/src/components/hud/TileSummary.tsx
+++ b/src/components/hud/TileSummary.tsx
@@ -1,4 +1,4 @@
-import { Card, CardContent, CardHeader, IconButton, Typography } from '@mui/material'
+import { Card, CardContent, CardHeader, IconButton } from '@mui/material'
 import { ProjectsDisplay } from './ProjectsDisplay'
 import { Tile } from '../../game_logic'
 import { gameDispatcher, uiDispatcher } from '../reducers'
@@ -28,7 +28,7 @@ export function TileSummary (props: {
         }
       />
       <CardContent>
-        <ProjectsDisplay tile={props.tile} dispatch={props.dispatchGame} />
+        <ProjectsDisplay tile={props.tile} dispatchGame={props.dispatchGame} />
       </CardContent>
     </Card>
   )

--- a/src/components/hud/TileSummary.tsx
+++ b/src/components/hud/TileSummary.tsx
@@ -1,18 +1,34 @@
-import { Card, CardContent, Typography } from '@mui/material'
+import { Card, CardContent, CardHeader, IconButton, Typography } from '@mui/material'
 import { ProjectsDisplay } from './ProjectsDisplay'
 import { Tile } from '../../game_logic'
-import { GameDispatch } from '../GameDisplay'
+import { gameDispatcher, uiDispatcher } from '../reducers'
+import CloseIcon from '@mui/icons-material/Close'
 
-export function TileSummary (props: {tile?: Tile, dispatch: GameDispatch}) {
+export function TileSummary (props: {
+  tile?: Tile,
+  dispatchGame: gameDispatcher,
+  dispatchUI: uiDispatcher
+}) {
   if (!props.tile) {
     return (<div />)
   }
 
+  const onCloseClick = () => {
+    props.dispatchUI({
+      type: 'deselectTile'
+    })
+  }
+
   return (
     <Card elevation={3}>
+      <CardHeader
+        title={`${props.tile.definition.name} Details`}
+        action={
+          <IconButton onClick={onCloseClick}><CloseIcon /></IconButton>
+        }
+      />
       <CardContent>
-        <Typography variant='h6'>{props.tile.definition.name}</Typography>
-        <ProjectsDisplay tile={props.tile} dispatch={props.dispatch} />
+        <ProjectsDisplay tile={props.tile} dispatch={props.dispatchGame} />
       </CardContent>
     </Card>
   )

--- a/src/components/hud/TileSummary.tsx
+++ b/src/components/hud/TileSummary.tsx
@@ -1,20 +1,19 @@
 import { Card, CardContent, CardHeader, IconButton } from '@mui/material'
 import { ProjectsDisplay } from './ProjectsDisplay'
 import { Tile } from '../../game_logic'
-import { gameDispatcher, uiDispatcher } from '../reducers'
+import { dispatcher } from '../reducers'
 import CloseIcon from '@mui/icons-material/Close'
 
 export function TileSummary (props: {
   tile?: Tile,
-  dispatchGame: gameDispatcher,
-  dispatchUI: uiDispatcher
+  dispatch: dispatcher
 }) {
   if (!props.tile) {
     return (<div />)
   }
 
   const onCloseClick = () => {
-    props.dispatchUI({
+    props.dispatch({
       type: 'deselectTile'
     })
   }
@@ -28,7 +27,7 @@ export function TileSummary (props: {
         }
       />
       <CardContent>
-        <ProjectsDisplay tile={props.tile} dispatchGame={props.dispatchGame} />
+        <ProjectsDisplay tile={props.tile} dispatch={props.dispatch} />
       </CardContent>
     </Card>
   )

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -1,11 +1,11 @@
 import { advanceTurn } from '../game_logic'
 import { GameState } from '../game_logic/interfaces'
 
-export interface UIState {
+export interface UiState {
   selectedTile?: number
 }
 
-export interface UIAction {
+export interface UiAction {
   type: 'selectTile' | 'deselectTile'
   tileIndex?: number
 }
@@ -24,7 +24,7 @@ export function gameReducer (state: GameState, action: GameAction): GameState {
   return Object.assign({}, state)
 }
 
-export function uiReducer (state: UIState, action: UIAction): UIState {
+export function uiReducer (state: UiState, action: UiAction): UiState {
   switch (action.type) {
     case 'selectTile':
       return Object.assign({}, state, { selectedTile: action.tileIndex })
@@ -37,5 +37,5 @@ export function uiReducer (state: UIState, action: UIAction): UIState {
       return Object.assign({}, state)
   }
 }
-export type uiDispatcher = (action: UIAction) => void
+export type uiDispatcher = (action: UiAction) => void
 export type gameDispatcher = (action: GameAction) => void

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -18,6 +18,7 @@ export interface GameAction {
 export function gameReducer (state: GameState, action: GameAction): GameState {
   console.log(action)
   switch (action.type) {
+    // TODO make advanceTurn a pure function?
     case 'advanceTurn':
       advanceTurn(state)
   }

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -5,38 +5,37 @@ export interface UIState {
   selectedTile?: number
 }
 
-export interface UIAction {
-  type: 'selectTile' | 'deselectTile'
+export interface Action {
+  type: 'selectTile' | 'deselectTile' | 'advanceTurn' | 'selectProject'
   tileIndex?: number
-}
-
-export interface GameAction {
-  type: 'advanceTurn' | 'selectProject'
   projectIndex?: number
 }
 
-export function gameReducer (state: GameState, action: GameAction): GameState {
+export interface State {
+  ui: UIState
+  game: GameState
+}
+
+export function reducer (state: State, action: Action): State {
   console.log(action)
   switch (action.type) {
     // TODO make advanceTurn a pure function?
     case 'advanceTurn':
-      advanceTurn(state)
-  }
-  return Object.assign({}, state)
-}
-
-export function uiReducer (state: UIState, action: UIAction): UIState {
-  switch (action.type) {
-    case 'selectTile':
-      return Object.assign({}, state, { selectedTile: action.tileIndex })
+      advanceTurn(state.game)
+      return Object.assign({}, state, { game: state.game })
+    case 'selectTile': {
+      const newState = Object.assign({}, state)
+      newState.ui.selectedTile = action.tileIndex
+      return newState
+    }
     case 'deselectTile': {
       const newState = Object.assign({}, state)
-      delete newState.selectedTile
+      delete newState.ui.selectedTile
       return newState
     }
     default:
       return Object.assign({}, state)
   }
 }
-export type uiDispatcher = (action: UIAction) => void
-export type gameDispatcher = (action: GameAction) => void
+
+export type dispatcher = (action: Action) => void

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -1,11 +1,11 @@
 import { advanceTurn } from '../game_logic'
 import { GameState } from '../game_logic/interfaces'
 
-export interface UiState {
+export interface UIState {
   selectedTile?: number
 }
 
-export interface UiAction {
+export interface UIAction {
   type: 'selectTile' | 'deselectTile'
   tileIndex?: number
 }
@@ -25,7 +25,7 @@ export function gameReducer (state: GameState, action: GameAction): GameState {
   return Object.assign({}, state)
 }
 
-export function uiReducer (state: UiState, action: UiAction): UiState {
+export function uiReducer (state: UIState, action: UIAction): UIState {
   switch (action.type) {
     case 'selectTile':
       return Object.assign({}, state, { selectedTile: action.tileIndex })
@@ -38,5 +38,5 @@ export function uiReducer (state: UiState, action: UiAction): UiState {
       return Object.assign({}, state)
   }
 }
-export type uiDispatcher = (action: UiAction) => void
+export type uiDispatcher = (action: UIAction) => void
 export type gameDispatcher = (action: GameAction) => void

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -1,0 +1,41 @@
+import { advanceTurn } from '../game_logic'
+import { GameState } from '../game_logic/interfaces'
+
+export interface UIState {
+  selectedTile?: number
+}
+
+export interface UIAction {
+  type: 'selectTile' | 'deselectTile'
+  tileIndex?: number
+}
+
+export interface GameAction {
+  type: 'advanceTurn'
+  projectIndex?: number
+}
+
+export function gameReducer (state: GameState, action: GameAction): GameState {
+  console.log(action)
+  switch (action.type) {
+    case 'advanceTurn':
+      advanceTurn(state)
+  }
+  return Object.assign({}, state)
+}
+
+export function uiReducer (state: UIState, action: UIAction): UIState {
+  switch (action.type) {
+    case 'selectTile':
+      return Object.assign({}, state, { selectedTile: action.tileIndex })
+    case 'deselectTile': {
+      const newState = Object.assign({}, state)
+      delete newState.selectedTile
+      return newState
+    }
+    default:
+      return Object.assign({}, state)
+  }
+}
+export type uiDispatcher = (action: UIAction) => void
+export type gameDispatcher = (action: GameAction) => void

--- a/src/components/reducers.ts
+++ b/src/components/reducers.ts
@@ -11,7 +11,7 @@ export interface UiAction {
 }
 
 export interface GameAction {
-  type: 'advanceTurn'
+  type: 'advanceTurn' | 'selectProject'
   projectIndex?: number
 }
 

--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -3,7 +3,7 @@ import { Canvas } from '@react-three/fiber'
 import { MapControls, Stats } from '@react-three/drei'
 import { Map } from './Map'
 import { GameState } from '../../game_logic'
-import { uiDispatcher, UIState } from '../reducers'
+import { uiDispatcher, UiState } from '../reducers'
 function PlainPlane () {
   return (
     <mesh
@@ -16,7 +16,7 @@ function PlainPlane () {
   )
 }
 
-export function GameView (props: {gameState: GameState, uiState: UIState, dispatchUi: uiDispatcher}) {
+export function GameView (props: {gameState: GameState, uiState: UiState, dispatchUi: uiDispatcher}) {
   //    -    +
   // X  Left Right
   // Y  Down Up

--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -3,7 +3,7 @@ import { Canvas } from '@react-three/fiber'
 import { MapControls, Stats } from '@react-three/drei'
 import { Map } from './Map'
 import { GameState } from '../../game_logic'
-import { uiDispatcher, UiState } from '../reducers'
+import { uiDispatcher, UIState } from '../reducers'
 function PlainPlane () {
   return (
     <mesh
@@ -16,7 +16,7 @@ function PlainPlane () {
   )
 }
 
-export function GameView (props: {gameState: GameState, uiState: UiState, dispatchUi: uiDispatcher}) {
+export function GameView (props: {gameState: GameState, uiState: UIState, dispatchUI: uiDispatcher}) {
   //    -    +
   // X  Left Right
   // Y  Down Up
@@ -28,7 +28,7 @@ export function GameView (props: {gameState: GameState, uiState: UiState, dispat
       <PlainPlane />
       <ambientLight intensity={0.3} />
       <directionalLight intensity={2} position={[-3, 10, 5]} />
-      <Map gridInterval={1} mapState={props.gameState.map} uiState={props.uiState} dispatchUi={props.dispatchUi} />
+      <Map gridInterval={1} mapState={props.gameState.map} uiState={props.uiState} dispatchUI={props.dispatchUI} />
       <Stats className='stats' showPanel={1} />
       <axesHelper args={[10]} />
     </>

--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -2,8 +2,7 @@ import * as THREE from 'three'
 import { Canvas } from '@react-three/fiber'
 import { MapControls, Stats } from '@react-three/drei'
 import { Map } from './Map'
-import { GameState } from '../../game_logic'
-import { uiDispatcher, UIState } from '../reducers'
+import { dispatcher, State } from '../reducers'
 function PlainPlane () {
   return (
     <mesh
@@ -16,7 +15,7 @@ function PlainPlane () {
   )
 }
 
-export function GameView (props: {gameState: GameState, uiState: UIState, dispatchUI: uiDispatcher}) {
+export function GameView (props: {state: State, dispatch: dispatcher}) {
   //    -    +
   // X  Left Right
   // Y  Down Up
@@ -28,14 +27,14 @@ export function GameView (props: {gameState: GameState, uiState: UIState, dispat
       <PlainPlane />
       <ambientLight intensity={0.3} />
       <directionalLight intensity={2} position={[-3, 10, 5]} />
-      <Map gridInterval={1} mapState={props.gameState.map} uiState={props.uiState} dispatchUI={props.dispatchUI} />
+      <Map gridInterval={1} mapState={props.state.game.map} uiState={props.state.ui} dispatch={props.dispatch} />
       <Stats className='stats' showPanel={1} />
       <axesHelper args={[10]} />
     </>
   )
 }
 
-export function GameViewPort (props) {
+export function GameViewPort (props: {state: State, dispatch: dispatcher}) {
   return (
     <Canvas
       camera={{ position: [10, 10, 30], fov: 45 }}

--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -3,7 +3,7 @@ import { Canvas } from '@react-three/fiber'
 import { MapControls, Stats } from '@react-three/drei'
 import { Map } from './Map'
 import { GameState } from '../../game_logic'
-import { uiDispatcher, UiState } from '../GameDisplay'
+import { uiDispatcher, UIState } from '../reducers'
 function PlainPlane () {
   return (
     <mesh
@@ -16,7 +16,7 @@ function PlainPlane () {
   )
 }
 
-export function GameView (props: {gameState: GameState, uiState: UiState, dispatchUi: uiDispatcher}) {
+export function GameView (props: {gameState: GameState, uiState: UIState, dispatchUi: uiDispatcher}) {
   //    -    +
   // X  Left Right
   // Y  Down Up

--- a/src/components/view/Map.tsx
+++ b/src/components/view/Map.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { MapState } from '../../game_logic'
-import { uiDispatcher, UiState } from '../GameDisplay'
+import { uiDispatcher, UIState } from '../reducers'
 import { MapLocation } from './MapLocation'
 import { Html, useProgress } from '@react-three/drei'
 
@@ -17,14 +17,14 @@ function Loader () {
  * @param props
  * @returns
  */
-export function Map (props: {mapState: MapState, gridInterval: number, uiState: UiState, dispatchUi: uiDispatcher}) {
+export function Map (props: {mapState: MapState, gridInterval: number, uiState: UIState, dispatchUi: uiDispatcher}) {
   const mapLocations = []
 
   for (let i = 0; i < props.mapState.size.x; i++) {
     for (let j = 0; j < props.mapState.size.y; j++) {
       const index = ijToIndex(i, j, props.mapState.size.x)
       mapLocations.push(
-        <Suspense fallback={<Loader />}>
+        <Suspense key={`${i},${j}`} fallback={<Loader />}>
           <MapLocation
             key={`${i}${j}`}
             row={i}

--- a/src/components/view/Map.tsx
+++ b/src/components/view/Map.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { MapState } from '../../game_logic'
-import { uiDispatcher, UiState } from '../reducers'
+import { uiDispatcher, UIState } from '../reducers'
 import { MapLocation } from './MapLocation'
 import { Html, useProgress } from '@react-three/drei'
 
@@ -17,7 +17,7 @@ function Loader () {
  * @param props
  * @returns
  */
-export function Map (props: {mapState: MapState, gridInterval: number, uiState: UiState, dispatchUi: uiDispatcher}) {
+export function Map (props: {mapState: MapState, gridInterval: number, uiState: UIState, dispatchUI: uiDispatcher}) {
   const mapLocations = []
 
   for (let i = 0; i < props.mapState.size.x; i++) {
@@ -33,7 +33,7 @@ export function Map (props: {mapState: MapState, gridInterval: number, uiState: 
             gridInterval={props.gridInterval}
             selected={props.uiState.selectedTile === index}
             onSelected={() => {
-              props.dispatchUi({ type: 'selectTile', tileIndex: index })
+              props.dispatchUI({ type: 'selectTile', tileIndex: index })
             }}
           />
         </Suspense>

--- a/src/components/view/Map.tsx
+++ b/src/components/view/Map.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { MapState } from '../../game_logic'
-import { uiDispatcher, UIState } from '../reducers'
+import { uiDispatcher, UiState } from '../reducers'
 import { MapLocation } from './MapLocation'
 import { Html, useProgress } from '@react-three/drei'
 
@@ -17,7 +17,7 @@ function Loader () {
  * @param props
  * @returns
  */
-export function Map (props: {mapState: MapState, gridInterval: number, uiState: UIState, dispatchUi: uiDispatcher}) {
+export function Map (props: {mapState: MapState, gridInterval: number, uiState: UiState, dispatchUi: uiDispatcher}) {
   const mapLocations = []
 
   for (let i = 0; i < props.mapState.size.x; i++) {

--- a/src/components/view/Map.tsx
+++ b/src/components/view/Map.tsx
@@ -1,6 +1,6 @@
 import { Suspense } from 'react'
 import { MapState } from '../../game_logic'
-import { uiDispatcher, UIState } from '../reducers'
+import { dispatcher, UIState } from '../reducers'
 import { MapLocation } from './MapLocation'
 import { Html, useProgress } from '@react-three/drei'
 
@@ -17,7 +17,7 @@ function Loader () {
  * @param props
  * @returns
  */
-export function Map (props: {mapState: MapState, gridInterval: number, uiState: UIState, dispatchUI: uiDispatcher}) {
+export function Map (props: {mapState: MapState, gridInterval: number, uiState: UIState, dispatch: dispatcher}) {
   const mapLocations = []
 
   for (let i = 0; i < props.mapState.size.x; i++) {
@@ -33,7 +33,7 @@ export function Map (props: {mapState: MapState, gridInterval: number, uiState: 
             gridInterval={props.gridInterval}
             selected={props.uiState.selectedTile === index}
             onSelected={() => {
-              props.dispatchUI({ type: 'selectTile', tileIndex: index })
+              props.dispatch({ type: 'selectTile', tileIndex: index })
             }}
           />
         </Suspense>


### PR DESCRIPTION
- added a close button to the tile summary pane so that users can free up screen real estate
- moved the reducer code to its own file for now, and made the names of the functions and types a bit more consistent
    - 'UI' is always rendered as `Ui`
    - Dispatchers, action types, and state types for game and UI state are prefixed with `game` and `ui`, respectively
    - Dispatcher functions are `gameDispatcher` and `uiDispatcher`, but when injected as props are named `dispatchGame` and `dispatchUi` respectively 

![tile_summary_pane_close](https://user-images.githubusercontent.com/5727397/146616000-7f55b606-47ee-48d2-82c1-932393da67bf.gif)
t