### PR TITLE
Replaced the summary pane with a strip at the top

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -67,6 +67,14 @@ html, body {
     overflow: hidden;
 }
 
+.player-summary-strip.player-summary-strip.player-summary-strip {
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
+    padding: 4px;
+    align-items: center;
+}
+
 /* the extra specifity is needed here to override @mui's styling */
 .hud-pane-expander.hud-pane-expander.hud-pane-expander.hud-pane-expander {
     margin: 24px 24px 0 24px;
@@ -76,19 +84,6 @@ html, body {
     vertical-align: middle;
 }
 
-.player-summary-pane-row {
-    border-bottom: none;
-}
-
-.player-summary-pane-row:hover {
-    background-color: rgb(0, 0, 0, 0.04);
-}
-
-.player-summary-pane-row > td {
-    padding: 5px 0;
-    text-align: left;
-    border-bottom: none;
-}
 .contract-list {
     margin-right: 16px;
 }

--- a/src/App.css
+++ b/src/App.css
@@ -71,13 +71,21 @@ html, body {
     display: flex;
     flex-direction: row;
     gap: 10px;
-    padding: 4px;
+    padding: 12px;
     align-items: center;
+    background-color: transparent;
+    color: #130701;
+    box-shadow: none;
+    padding-left: 24px;
+}
+
+.player-summary-strip>.MuiTypography-root {
+    min-width: 100px;
 }
 
 /* the extra specifity is needed here to override @mui's styling */
 .hud-pane-expander.hud-pane-expander.hud-pane-expander.hud-pane-expander {
-    margin: 24px 24px 0 24px;
+    margin: 48px 24px 0 24px;
 }
 
 .MuiSvgIcon-root {

--- a/src/components/hud/Hud.tsx
+++ b/src/components/hud/Hud.tsx
@@ -4,7 +4,7 @@ import { Tile } from '../../game_logic'
 import { ContractPane } from './ContractPane'
 import { State, dispatcher } from '../reducers'
 import { TileSummary } from './TileSummary'
-import { PlayerSummaryPane } from './PlayerSummaryPane'
+import { PlayerSummaryStrip } from './PlayerSummaryStrip'
 import NextPlanIcon from '@mui/icons-material/NextPlan'
 
 export function Hud (props: {
@@ -25,16 +25,7 @@ export function Hud (props: {
   return (
     <>
       <div className='hud'>
-        <Accordion defaultExpanded className='hud-pane-expander'>
-          <AccordionSummary
-            expandIcon={<ExpandMoreIcon />}
-          >
-            <Typography variant='h6'>Summary</Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            <PlayerSummaryPane id='playerSummaryPane' playerState={props.state.game.player} />
-          </AccordionDetails>
-        </Accordion>
+        <PlayerSummaryStrip id='playerSummaryPane' playerState={props.state.game.player} />
         <Accordion defaultExpanded className='hud-pane-expander'>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography variant='h6'>Contracts</Typography>

--- a/src/components/hud/Hud.tsx
+++ b/src/components/hud/Hud.tsx
@@ -25,7 +25,7 @@ export function Hud (props: {
   return (
     <>
       <div className='hud'>
-        <PlayerSummaryStrip id='playerSummaryPane' playerState={props.state.game.player} />
+        <PlayerSummaryStrip gameState={props.state.game} />
         <Accordion defaultExpanded className='hud-pane-expander'>
           <AccordionSummary expandIcon={<ExpandMoreIcon />}>
             <Typography variant='h6'>Contracts</Typography>

--- a/src/components/hud/PlayerSummaryStrip.tsx
+++ b/src/components/hud/PlayerSummaryStrip.tsx
@@ -1,4 +1,4 @@
-import { Chip, Table, TableBody, TableCell, TableRow, Typography } from '@mui/material'
+import { AppBar, Chip, Divider, Typography } from '@mui/material'
 import { ComponentPropsWithoutRef } from 'react'
 import { PlayerState } from '../../game_logic'
 
@@ -12,25 +12,15 @@ type SummaryPaneRowProps = {
   }
 }
 
-function summaryPaneRow (props: SummaryPaneRowProps) {
-  return (
-    <TableRow key={props.icon} className='player-summary-pane-row'>
-      <TableCell><i className='material-icons'>{props.icon}</i></TableCell>
-      <TableCell><Typography>{props.value}</Typography></TableCell>
-      <TableCell>{props.chip && <Chip label={props.chip.caption} color={props.chip.color} />}</TableCell>
-    </TableRow>
-  )
-}
-
 function formatRevenue (value: number) {
   if (value >= 0) {
-    return `+ $${Math.abs(value)}`
+    return `+$${Math.abs(value)}`
   } else {
-    return `- $${Math.abs(value)}`
+    return `-$${Math.abs(value)}`
   }
 }
 
-export function PlayerSummaryPane (props: {id: string, playerState: PlayerState}) {
+export function PlayerSummaryStrip (props: {id: string, playerState: PlayerState}) {
   const summary: SummaryPaneRowProps[] = [
     {
       icon: 'attach_money',
@@ -53,12 +43,14 @@ export function PlayerSummaryPane (props: {id: string, playerState: PlayerState}
       }
     }
   ]
-  const rows = summary.map(row => summaryPaneRow(row))
+
+  const revenue = props.playerState.resources.money.revenue
+
   return (
-    <Table id={props.id} className='player-summary-pane pane'>
-      <TableBody>
-        {rows}
-      </TableBody>
-    </Table>
+    <AppBar id={props.id} className='player-summary-strip'>
+      <Typography>${props.playerState.resources.money.balance}</Typography>
+      <Chip color={revenue < 0 ? 'error' : 'default'} label={formatRevenue(revenue)} />
+      <Divider orientation='vertical' variant='middle' />
+    </AppBar>
   )
 }

--- a/src/components/hud/PlayerSummaryStrip.tsx
+++ b/src/components/hud/PlayerSummaryStrip.tsx
@@ -1,16 +1,5 @@
-import { AppBar, Chip, Divider, Typography } from '@mui/material'
-import { ComponentPropsWithoutRef } from 'react'
-import { PlayerState } from '../../game_logic'
-
-type MuiColor = ComponentPropsWithoutRef<typeof Chip>['color']
-type SummaryPaneRowProps = {
-  icon: string
-  value: number
-  chip?: {
-    caption: string
-    color: MuiColor
-  }
-}
+import { AppBar, Badge, Chip, Divider, Typography } from '@mui/material'
+import { GameState } from '../../game_logic'
 
 function formatRevenue (value: number) {
   if (value >= 0) {
@@ -20,37 +9,25 @@ function formatRevenue (value: number) {
   }
 }
 
-export function PlayerSummaryStrip (props: {id: string, playerState: PlayerState}) {
-  const summary: SummaryPaneRowProps[] = [
-    {
-      icon: 'attach_money',
-      value: props.playerState.resources.money.balance,
-      chip: {
-        caption: formatRevenue(props.playerState.resources.money.revenue),
-        color: 'primary'
-      }
-    },
-    {
-      icon: 'sentiment_satisfied_alt',
-      value: props.playerState.victory.happiness
-    },
-    {
-      icon: 'person',
-      value: props.playerState.resources.workers.max,
-      chip: {
-        caption: `${props.playerState.resources.workers.free} idle`,
-        color: 'warning'
-      }
-    }
-  ]
-
-  const revenue = props.playerState.resources.money.revenue
+export function PlayerSummaryStrip (props: {gameState: GameState}) {
+  const revenue = props.gameState.player.resources.money.revenue
+  const idle = props.gameState.player.resources.workers.free
 
   return (
-    <AppBar id={props.id} className='player-summary-strip'>
-      <Typography>${props.playerState.resources.money.balance}</Typography>
-      <Chip color={revenue < 0 ? 'error' : 'default'} label={formatRevenue(revenue)} />
+    <AppBar className='player-summary-strip'>
+      <Typography>${props.gameState.player.resources.money.balance}</Typography>
       <Divider orientation='vertical' variant='middle' />
+      <Typography>{formatRevenue(revenue)}/turn</Typography>
+      <Divider orientation='vertical' variant='middle' />
+      <Typography>🙂{props.gameState.player.victory.happiness}</Typography>
+      <Divider orientation='vertical' variant='middle' />
+      <Typography>
+        <Badge invisible={idle < 1} badgeContent={idle} color='primary'>
+          👤{props.gameState.player.resources.workers.max}
+        </Badge>
+      </Typography>
+      <Divider orientation='vertical' variant='middle' />
+      <Typography>↩️{props.gameState.game.turnCounter}</Typography>
     </AppBar>
   )
 }


### PR DESCRIPTION
- It includes the following fields:
  - balance
  - revenue
  - happiness
  - workers (with a badge indicating the number idle)
  - current turn
- I am working on the contracts pane in a separate change list

![image](https://user-images.githubusercontent.com/5727397/147368704-614918e1-46c8-4b48-9878-d19bcadd5af3.png)
