### PR TITLE
Change `resetWorkers` to `adjustWorkers` to avoid tedious re-assignment

### DIFF
--- a/src/game_logic/index.ts
+++ b/src/game_logic/index.ts
@@ -1,7 +1,7 @@
 import { enableMapSet } from 'immer'
 
-import { Contract, GameState, Tile, TileType } from './interfaces'
-import { advanceTurnCounter, applyRevenue, applyWorkers, resetWorkers, resolveContracts } from './turn'
+import { GameState, Tile, TileType, Contract } from './interfaces'
+import { advanceTurnCounter, applyRevenue, applyWorkers, adjustWorkers, resolveContracts } from './turn'
 import { map as mapDefinition } from '../data/map'
 import { contractQueue } from '../data/contract-catalog'
 import { NUM_OPEN_CONTRACTS } from './constants'
@@ -68,7 +68,7 @@ export function advanceTurn (initialState: GameState): GameState {
   let state = initialState
   state = applyRevenue(state)
   state = applyWorkers(state)
-  state = resetWorkers(state)
+  state = adjustWorkers(state)
   state = resolveContracts(state)
   state = advanceTurnCounter(state)
   // checkWinLoss(state)

--- a/src/game_logic/shared.ts
+++ b/src/game_logic/shared.ts
@@ -1,9 +1,3 @@
-/**
- * Takes an `array` of nonprimitives and replaces the `oldItem` with the `newItem`.
- * Prints an assertion when the `oldItem` can't be found or is found multiple times.
- */
-export function replaceOne<T1 extends object, T2 extends T1> (array: ReadonlyArray<T1>, oldItem: T1, newItem: T2): ReadonlyArray<T1> {
-  const indexes = array.flatMap((v, i) => v === oldItem ? i : [])
-  console.assert(indexes.length === 1)
-  return [...array].splice(indexes[0], 1, newItem)
+export function clamp (number: number, min: number, max: number) {
+  return Math.min(Math.max(number, min), max)
 }

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,3 +1,0 @@
-export function clamp (number: number, min: number, max: number) {
-  return Math.min(Math.max(number, min), max)
-}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -1,0 +1,3 @@
+export function clamp (number: number, min: number, max: number) {
+  return Math.min(Math.max(number, min), max)
+}


### PR DESCRIPTION
* Now the workers assigned to project remains unchanged, unless the assigned workers exceeds the remaining effort
* If extra workers, those are refunded to player