### PR TITLE
limit camera angles to preven ppl from looking at the map's underside

### DIFF
--- a/src/components/view/GameViewPort.tsx
+++ b/src/components/view/GameViewPort.tsx
@@ -31,7 +31,7 @@ function GameView (props: GameViewProps) {
 
   return (
     <>
-      <MapControls target={[10, 0, 10]} />
+      <MapControls maxPolarAngle={1 / 2 * Math.PI - Math.PI / 16} target={[10, 0, 10]} />
       <PlainPlane />
       <Skybox />
       <ambientLight intensity={0.3} />


### PR DESCRIPTION
- limit the camera to slightly above the ground plain, to prevent gamers from peeking at our map's underside

![camera-limits](https://user-images.githubusercontent.com/5727397/147717500-28a09346-d7f6-4a61-bf7f-bc9c01e27532.gif)
