### PR TITLE
Fix aura making the canvas transparent

### DIFF
--- a/src/components/view/SelectAura.tsx
+++ b/src/components/view/SelectAura.tsx
@@ -1,7 +1,7 @@
 import * as THREE from 'three'
 
-const AURA_BOTTOM_ALPHA = 0.2
-const AURA_BOTTOM_PLANE_ALPHA = 0.7
+const AURA_ALPHA_START = 0.7
+const AURA_ALPHA_BOTTOM = 0.7
 const AURA_HEIGHT = 2
 
 const vertexShader = `
@@ -20,7 +20,7 @@ varying vec2 vUv;
 
 void main() {
   gl_FragColor = mix(
-    vec4(color, ${AURA_BOTTOM_ALPHA}),
+    vec4(color, ${AURA_ALPHA_START}),
     vec4(color, 0.0),
     vUv.y
   );
@@ -38,8 +38,8 @@ type SelectAuraProps = {
 export function SelectAura (props: SelectAuraProps) {
   const selected = props.selected
   const hover = props.selected ? false : props.hover
-  const theColor = props.selected ? new THREE.Color('#c85136') : new THREE.Color('#7f7f7f')
-  const theBottomColor = props.selected ? new THREE.Color('#ff0000') : new THREE.Color('#343434')
+  const color = props.selected ? new THREE.Color('#FF6D6D') : new THREE.Color('#ffffff')
+  const colorBottom = props.selected ? new THREE.Color('#FF0000') : new THREE.Color('#ffffff')
 
   return (
     <group
@@ -47,10 +47,10 @@ export function SelectAura (props: SelectAuraProps) {
       position={[0.5, 0, 0.5]}
       scale={[1.001, 1, 1.001]}
     >
-      <AuraSide rotation={0} color={theColor} />
-      <AuraSide rotation={1} color={theColor} />
-      <AuraSide rotation={2} color={theColor} />
-      <AuraSide rotation={3} color={theColor} />
+      <AuraSide rotation={0} color={color} />
+      <AuraSide rotation={1} color={color} />
+      <AuraSide rotation={2} color={color} />
+      <AuraSide rotation={3} color={color} />
       <mesh
         rotation={new THREE.Euler(-Math.PI / 2)}
         position={[0, 0.002, 0]}
@@ -58,8 +58,8 @@ export function SelectAura (props: SelectAuraProps) {
         <planeGeometry args={[1, 1]} />
         <meshStandardMaterial
           args={[{
-            color: theBottomColor,
-            opacity: AURA_BOTTOM_PLANE_ALPHA,
+            color: colorBottom,
+            opacity: AURA_ALPHA_BOTTOM,
             depthWrite: false,
             transparent: true
           }]}

--- a/src/components/view/SelectAura.tsx
+++ b/src/components/view/SelectAura.tsx
@@ -60,7 +60,8 @@ export function SelectAura (props: SelectAuraProps) {
           args={[{
             color: theBottomColor,
             opacity: AURA_BOTTOM_PLANE_ALPHA,
-            blending: THREE.CustomBlending
+            depthWrite: false,
+            transparent: true
           }]}
         />
       </mesh>
@@ -91,7 +92,7 @@ function AuraSide (props: AuraSideProps) {
             },
             vertexShader,
             fragmentShader,
-            blending: THREE.CustomBlending,
+            transparent: true,
             depthWrite: false
           }]}
           side={THREE.FrontSide}


### PR DESCRIPTION
Requires #36 .

Before: The selection aura was setting the alpha of the canvas, allowing the white background of <body> underneath it to peek through.

After:
![1640852626876](https://user-images.githubusercontent.com/3746656/147734343-883afe9b-3ad1-4c44-88e9-cfc5d83106f1.png)
