### PR TITLE
use an hourglass icon for the turn count

### DIFF
--- a/src/components/hud/PlayerSummaryStrip.tsx
+++ b/src/components/hud/PlayerSummaryStrip.tsx
@@ -27,7 +27,7 @@ export function PlayerSummaryStrip (props: {gameState: GameState}) {
         </Badge>
       </Typography>
       <Divider orientation='vertical' variant='middle' />
-      <Typography>↩️{props.gameState.game.turnCounter}</Typography>
+      <Typography>⌛{props.gameState.game.turnCounter}</Typography>
     </AppBar>
   )
 }

--- a/src/components/hud/PlayerSummaryStrip.tsx
+++ b/src/components/hud/PlayerSummaryStrip.tsx
@@ -27,7 +27,7 @@ export function PlayerSummaryStrip (props: {gameState: GameState}) {
         </Badge>
       </Typography>
       <Divider orientation='vertical' variant='middle' />
-      <Typography>⌛{props.gameState.game.turnCounter}</Typography>
+      <Typography>Turns Elapsed: {props.gameState.game.turnCounter}</Typography>
     </AppBar>
   )
 }


### PR DESCRIPTION
I switched the turn count icon to just display `Turns Elapsed`:
![image](https://user-images.githubusercontent.com/5727397/147786590-9c3674c5-cec3-4849-be1e-21966b42a652.png)

I think this is easier to understand, what do you guys think?